### PR TITLE
Rename app to "Admin GraphQL IDE"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
-  # Admin GraphiQL - VTEX IO
+  # Admin GraphQL IDE - VTEX IO
 
   Select your app and start **writing**, **simulating** and **testing requests** to validate your GraphQL API using `GraphiQL` (a graphical interactive in-browser GraphQL IDE).

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "admin-graphql-ide",
   "vendor": "vtex",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "title": "Admin GraphQL IDE",
   "description": "GraphQL IDE for VTEX Admin (GraphiQL)",
   "scripts": {

--- a/manifest.json
+++ b/manifest.json
@@ -1,9 +1,9 @@
 {
-  "name": "admin-graphiql",
+  "name": "admin-graphql-ide",
   "vendor": "vtex",
   "version": "0.2.0",
-  "title": "Admin GraphiQL",
-  "description": "GraphiQL IDE for VTEX Admin",
+  "title": "Admin GraphQL IDE",
+  "description": "GraphQL IDE for VTEX Admin (GraphiQL)",
   "scripts": {
     "prereleasy": "bash pre.sh"
   },


### PR DESCRIPTION
Rename app to `Admin GraphQL IDE` (clearer and easier than its previous name - `Admin GraphiQL`).