### PR TITLE
Continue the process of changing the name of the app

### DIFF
--- a/admin/navigation.json
+++ b/admin/navigation.json
@@ -1,5 +1,0 @@
-{
-    "section": "storeSetup",
-    "titleId": "admin.graphiql.title",
-    "path": "/admin/graphiql"
-}

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "admin-graphql-ide",
   "vendor": "vtex",
-  "version": "0.3.1-beta.0",
+  "version": "0.3.1",
   "title": "Admin GraphQL IDE",
   "description": "GraphQL IDE for VTEX Admin (GraphiQL)",
   "scripts": {

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "name": "admin-graphql-ide",
   "vendor": "vtex",
-  "version": "0.3.0",
+  "version": "0.3.1-beta.0",
   "title": "Admin GraphQL IDE",
   "description": "GraphQL IDE for VTEX Admin (GraphiQL)",
   "scripts": {

--- a/messages/en.json
+++ b/messages/en.json
@@ -3,6 +3,6 @@
     "admin/error.title": "Something went wrong",
     "admin/no-app-selected.title": "Choose an App",
     "admin/no-app-selected.state": "Choose an App to make queries",
-    "admin/layout.title": "Admin GraphiQL",
+    "admin/layout.title": "GraphQL IDE",
     "admin/controller.app-picker": "Choose an App"
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -3,6 +3,6 @@
   "admin/error.title": "Algo de errado aconteceu",
   "admin/no-app-selected.title": "Escolha uma App",
   "admin/no-app-selected.state": "Selecione uma App para realizar queries",
-  "admin/layout.title": "Admin GraphiQL",
+  "admin/layout.title": "GraphQL IDE",
   "admin/controller.app-picker": "Selecione uma App"
 }

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -3,6 +3,6 @@
   "admin/error.title": "Algo de errado aconteceu",
   "admin/no-app-selected.title": "Escolha uma App",
   "admin/no-app-selected.state": "Selecione uma App para realizar queries",
-  "admin/layout.title": "Admin GraphiQL",
+  "admin/layout.title": "GraphQL IDE",
   "admin/controller.app-picker": "Selecione uma App"
 }

--- a/node/middlewares/graphqlProxy.ts
+++ b/node/middlewares/graphqlProxy.ts
@@ -15,12 +15,12 @@ export const ensureAdminUser = async (clients: Pick<Clients, 'sphinx' | 'vtexID'
 
   const {user: email} = (await vtexID.getIdUser(idToken)) || EMPTY_OBJECT as any
   if (!email) {
-    throw new ForbiddenError('User must have a valid email to use admin-graphiql')
+    throw new ForbiddenError('User must have a valid email to use admin-graphql-ide')
   }
 
   const isAdminUser = await sphinx.isAdmin(email)
   if (!isAdminUser) {
-    throw new ForbiddenError('User must be admin to use admin-graphiql')
+    throw new ForbiddenError('User must be admin to use admin-graphql-ide')
   }
 }
 

--- a/node/service.json
+++ b/node/service.json
@@ -6,7 +6,7 @@
   "maxReplicas": 4,
   "routes": {
     "graphqlProxy": {
-      "path": "/_v/private/admin-graphiql/v0/:appId",
+      "path": "/_v/private/admin-graphql-ide/v0/:appId",
       "public": true
     }
   }

--- a/pages/blocks.json
+++ b/pages/blocks.json
@@ -1,8 +1,8 @@
 {
-    "inject#admin-graphiql": {
+    "inject#admin-graphql-ide": {
         "props": {
             "titleId": "admin/layout.title",
-            "path": "/admin/graphiql",
+            "path": "/admin/graphql-ide",
             "group": "storeSetup",
             "icon": "master-data-ic"
         }

--- a/pages/interfaces.json
+++ b/pages/interfaces.json
@@ -1,5 +1,5 @@
 {
-  "admin.graphiql": {
+  "admin.graphql-ide": {
     "component": "GraphiQL",
     "around": ["layout"]
   },

--- a/pages/plugins.json
+++ b/pages/plugins.json
@@ -1,3 +1,3 @@
 {
-    "navigation > inject": "inject#admin-graphiql"
+    "navigation > inject": "inject#admin-graphql-ide"
 }

--- a/pages/routes.json
+++ b/pages/routes.json
@@ -1,5 +1,5 @@
 {
-  "admin.graphiql": {
-    "path": "/admin/graphiql"
+  "admin.graphql-ide": {
+    "path": "/admin/graphql-ide"
   }
 }

--- a/react/PageLayout.tsx
+++ b/react/PageLayout.tsx
@@ -5,7 +5,7 @@ import { Layout, PageBlock, PageHeader } from 'vtex.styleguide'
 const messages = defineMessages({
   title: {
     id: 'admin/layout.title',
-    defaultMessage: 'Admin GraphiQL'
+    defaultMessage: 'GraphQL IDE'
   }
 })
 

--- a/react/components/Controller.tsx
+++ b/react/components/Controller.tsx
@@ -30,7 +30,7 @@ interface Props extends InjectedIntlProps {
   apps: string[]
 }
 
-const fetcherForApp = (appId: string) => (params: any) => fetch(`/_v/private/admin-graphiql/v0/${appId}`, {
+const fetcherForApp = (appId: string) => (params: any) => fetch(`/_v/private/admin-graphql-ide/v0/${appId}`, {
   body: JSON.stringify(params),
   headers: { 'Content-Type': 'application/json' },
   method: 'post',

--- a/react/graphql/apps.graphql
+++ b/react/graphql/apps.graphql
@@ -1,3 +1,3 @@
 query GetApps {
-  apps @context(provider: "vtex.admin-graphiql")
+  apps @context(provider: "vtex.admin-graphql-ide")
 }


### PR DESCRIPTION
Rename `routes`, `paths`, and other variables and titles to be coherent with the new name of the app.