### PR TITLE
Transfer cookies to graphql-server now

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -38,5 +38,6 @@
         "path": "/api/vtexid/pub/authenticated/user"
       }
     }
-  ]
+  ],
+  "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"
 }

--- a/node/clients/graphqlServer.ts
+++ b/node/clients/graphqlServer.ts
@@ -5,8 +5,9 @@ export class GraphQLServer extends AppClient {
     super('vtex.graphql-server', ctx, opts)
   }
 
-  public proxyGraphiQL = (body: any, appId: string) => this.http.post('/graphiql', body, {
+  public proxyGraphiQL = (body: any, appId: string, headers: Record<string, string>) => this.http.post('/graphiql', body, {
     headers: {
+      ...headers,
       'x-colossus-declarer-id': appId,
     },
   })

--- a/node/package.json
+++ b/node/package.json
@@ -16,7 +16,7 @@
     "prettier": "^1.16.4",
     "tslint": "^5.12.0",
     "tslint-config-vtex": "^2.1.0",
-    "typescript": "^3.4.5"
+    "typescript": "3.5.2"
   },
   "scripts": {
     "check": "tsc --noEmit && tslint -c tslint.json './**/*.ts'"

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -2331,10 +2331,10 @@ type-is@^1.6.16:
     media-typer "0.3.0"
     mime-types "~2.1.18"
 
-typescript@^3.4.5:
-  version "3.4.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.4.5.tgz#2d2618d10bb566572b8d7aad5180d84257d70a99"
-  integrity sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw==
+typescript@3.5.2:
+  version "3.5.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.2.tgz#a09e1dc69bc9551cadf17dba10ee42cf55e5d56c"
+  integrity sha512-7KxJovlYhTX5RaRbUdkAXN1KUZ8PwWlTzQdHV6xNqvuFOs7+WBo10TQUqT19Q/Jz2hk5v9TQDIhyLhhJY4p5AA==
 
 universalify@^0.1.0:
   version "0.1.2"

--- a/react/components/Controller.tsx
+++ b/react/components/Controller.tsx
@@ -55,8 +55,8 @@ class GraphiQLControllerComponent extends React.Component<Props, State> {
     }
   }
 
-  public setState = (state: ((x: State) => State) | Partial<State>, cb?: () => void) => {
-    const {schema, chosenAppId, error, fetcher} = typeof state === 'function' ? state(this.state) : {...this.state, ...state}
+  public setState = (state: any, cb?: () => void) => {
+    const { schema, chosenAppId, error, fetcher }: any = typeof state === 'function' ? state(this.state) : { ...this.state, ...state }
     let mode: ViewState
     if (error) {
       mode = ViewState.ON_ERROR
@@ -67,9 +67,9 @@ class GraphiQLControllerComponent extends React.Component<Props, State> {
     } else {
       mode = ViewState.ON_SELECT_APP
     }
-    
+
     super.setState({
-      schema, 
+      schema,
       chosenAppId,
       error,
       fetcher,
@@ -89,9 +89,9 @@ class GraphiQLControllerComponent extends React.Component<Props, State> {
       <div className="mb5 z-max">
         <EXPERIMENTAL_Select
           label={this.props.intl.formatMessage(messages.appChooser)}
-          options={this.props.apps.map(app => ({value: app, label: app}))}
+          options={this.props.apps.map(app => ({ value: app, label: app }))}
           multi={false}
-          onChange={(chosen: {value?: string} | null) => this.setState(
+          onChange={(chosen: { value?: string } | null) => this.setState(
             (oldState: State) => {
               const chosenAppId = chosen ? chosen.value : undefined
               return {
@@ -106,33 +106,33 @@ class GraphiQLControllerComponent extends React.Component<Props, State> {
       </div>
       {
         this.state.mode === ViewState.ON_GRAPHIQL
-        ? (
-          <GraphiQL 
-            fetcher={this.state.fetcher} 
-            storage={getOrCreateScopedStorage(this.state.chosenAppId!)}
-            schema={this.state.schema}
-          />
-        )
-        : this.state.mode === ViewState.ON_SELECT_APP
-        ? (
-          <NoAppSelected />
-        )
-        : this.state.mode === ViewState.ON_FETCHING_SCHEMA
-        ? (
-          <Spinner />
-        )
-        : (
-          <ErrorState
-            onRetryClick={() => this.setState({error: false})} 
-          />
-        )
+          ? (
+            <GraphiQL
+              fetcher={this.state.fetcher}
+              storage={getOrCreateScopedStorage(this.state.chosenAppId!)}
+              schema={this.state.schema}
+            />
+          )
+          : this.state.mode === ViewState.ON_SELECT_APP
+            ? (
+              <NoAppSelected />
+            )
+            : this.state.mode === ViewState.ON_FETCHING_SCHEMA
+              ? (
+                <Spinner />
+              )
+              : (
+                <ErrorState
+                  onRetryClick={() => this.setState({ error: false })}
+                />
+              )
       }
     </Fragment>
   )
 
   private fetchSchema = async () => {
     try {
-      const response = await this.state.fetcher!({query: introspectionQuery})
+      const response = await this.state.fetcher!({ query: introspectionQuery })
       const schema = path(['data'], response) as IntrospectionQuery | undefined
       this.setState({
         schema: schema && buildClientSchema(schema),
@@ -140,7 +140,7 @@ class GraphiQLControllerComponent extends React.Component<Props, State> {
       })
     }
     catch (_) {
-      this.setState({error: true})
+      this.setState({ error: true })
     }
   }
 }

--- a/react/package.json
+++ b/react/package.json
@@ -21,7 +21,7 @@
     "eslint-config-vtex-react": "^4.1.0",
     "tslint": "^5.12.0",
     "tslint-config-vtex": "^2.1.0",
-    "typescript": "^3.4.2"
+    "typescript": "3.5.2"
   },
   "scripts": {
     "lint": "tsc --noEmit && tslint -c tslint.json './**/*.ts'"

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -1507,10 +1507,10 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
-typescript@^3.4.2:
-  version "3.4.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.4.5.tgz#2d2618d10bb566572b8d7aad5180d84257d70a99"
-  integrity sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw==
+typescript@3.5.2:
+  version "3.5.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.2.tgz#a09e1dc69bc9551cadf17dba10ee42cf55e5d56c"
+  integrity sha512-7KxJovlYhTX5RaRbUdkAXN1KUZ8PwWlTzQdHV6xNqvuFOs7+WBo10TQUqT19Q/Jz2hk5v9TQDIhyLhhJY4p5AA==
 
 uc.micro@^1.0.1, uc.micro@^1.0.5:
   version "1.0.6"


### PR DESCRIPTION
Cookies, when passing through the `admin-graphql-ide`, are transferred to `graphql-server` now (as they should since the beginning).