### PR TITLE
Adds huge timeout to graphql-server connection

### DIFF
--- a/node/index.ts
+++ b/node/index.ts
@@ -9,6 +9,7 @@ const appsCacheStorage = new LRUCache<string, any>({
 })
 
 const SHORT_TIMEOUT_MS = 1 * 500
+const GRAPHQL_SERVER_TIMEOUT_MS = 60e3
 
 metrics.trackCache('apps', appsCacheStorage)
 
@@ -21,6 +22,9 @@ export default new Service<Clients>({
         retries: 1,
         timeout: SHORT_TIMEOUT_MS,
       },
+      graphqlServer: {
+        timeout: GRAPHQL_SERVER_TIMEOUT_MS
+      }
     },
   },
   graphql: {

--- a/node/package.json
+++ b/node/package.json
@@ -16,7 +16,7 @@
     "prettier": "^1.16.4",
     "tslint": "^5.12.0",
     "tslint-config-vtex": "^2.1.0",
-    "typescript": "3.5.2"
+    "typescript": "3.8.3"
   },
   "scripts": {
     "check": "tsc --noEmit && tslint -c tslint.json './**/*.ts'"

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -2331,10 +2331,10 @@ type-is@^1.6.16:
     media-typer "0.3.0"
     mime-types "~2.1.18"
 
-typescript@3.5.2:
-  version "3.5.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.2.tgz#a09e1dc69bc9551cadf17dba10ee42cf55e5d56c"
-  integrity sha512-7KxJovlYhTX5RaRbUdkAXN1KUZ8PwWlTzQdHV6xNqvuFOs7+WBo10TQUqT19Q/Jz2hk5v9TQDIhyLhhJY4p5AA==
+typescript@3.8.3:
+  version "3.8.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
+  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
 
 universalify@^0.1.0:
   version "0.1.2"

--- a/react/package.json
+++ b/react/package.json
@@ -21,7 +21,7 @@
     "eslint-config-vtex-react": "^4.1.0",
     "tslint": "^5.12.0",
     "tslint-config-vtex": "^2.1.0",
-    "typescript": "3.5.2"
+    "typescript": "3.8.3"
   },
   "scripts": {
     "lint": "tsc --noEmit && tslint -c tslint.json './**/*.ts'"

--- a/react/yarn.lock
+++ b/react/yarn.lock
@@ -1507,10 +1507,10 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
-typescript@3.5.2:
-  version "3.5.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.5.2.tgz#a09e1dc69bc9551cadf17dba10ee42cf55e5d56c"
-  integrity sha512-7KxJovlYhTX5RaRbUdkAXN1KUZ8PwWlTzQdHV6xNqvuFOs7+WBo10TQUqT19Q/Jz2hk5v9TQDIhyLhhJY4p5AA==
+typescript@3.8.3:
+  version "3.8.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
+  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
 
 uc.micro@^1.0.1, uc.micro@^1.0.5:
   version "1.0.6"


### PR DESCRIPTION
GraphQL Server client did not have a timeout set. This made the client to use the fallback of 1s. If a timeout occurred we got the error "cannot read property banana of undefined"