### PR TITLE
Add German translations to make it available across Admin.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- German translation.
+
 ## [3.6.2] - 2022-09-29
 
 ### Fixed

--- a/messages/de.json
+++ b/messages/de.json
@@ -1,0 +1,8 @@
+{
+    "admin/error.state": "Versuchen Sie es erneut",
+    "admin/error.title": "Ein Problem ist aufgetreten",
+    "admin/no-app-selected.title": "Wählen Sie eine App aus",
+    "admin/no-app-selected.state": "Wählen Sie eine App für Abfragen",
+    "admin/layout.title": "GraphQL IDE",
+    "admin/controller.app-picker": "Wählen Sie eine App aus"
+}


### PR DESCRIPTION
This is part of a series of PRs in several apps to make German available across the Admin. Tracked in task [LOC-9843](https://vtex-dev.atlassian.net/browse/LOC-9843).
A test store with DE in the language switcher is [available here](https://localizationqa--obidev.myvtex.com/admin/).

[LOC-9843]: https://vtex-dev.atlassian.net/browse/LOC-9843?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ